### PR TITLE
Filter scope by client/user

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -143,9 +143,10 @@ Note: see https://github.com/thomseddon/node-oauth2-server/tree/master/examples/
  - *boolean|string* **invalid**
      - Falsey to indicate token possesses required scope; truthy (boolean or string) as invalid scope error message
 
-### validateScope (scope, clientId, callback)
+### validateScope (scope, client, user, callback)
 - *string* **scope**
-- *string* **clientId**
+- *object* **client**
+- *object* **user**
 - *function* **callback (error, validScope, invalid)**
  - *mixed* **error**
      - Truthy to indicate an error

--- a/Readme.md
+++ b/Readme.md
@@ -200,11 +200,12 @@ Note: see https://github.com/thomseddon/node-oauth2-server/tree/master/examples/
 
 ### Required for `refresh_token` grant type
 
-#### saveRefreshToken (refreshToken, clientId, expires, user, callback)
+#### saveRefreshToken (refreshToken, clientId, expires, user, scope, callback)
 - *string* **refreshToken**
 - *string* **clientId**
 - *date* **expires**
 - *object* **user**
+- *string* **scope**
 - *function* **callback (error)**
  - *mixed* **error**
      - Truthy to indicate an error

--- a/examples/postgresql/model.js
+++ b/examples/postgresql/model.js
@@ -134,22 +134,24 @@ model.authoriseScope = function (accessToken, scope, callback) {
 
 model.validateScope = function (scope, client, user, callback) {
   // Sanitize the requested scope string against a client-specific set of valid scope keys
+  // and the scopes the user actually is allowed to use (if any).
   // You could choose to strip invalid keys, or return an error message
-  scope = scope || client.defaultScope || false;
-  var validScopes = client.validScopes;
-  var isValid = !scope || scope.split(' ').every(function(key) {
+  var requestedScope = scope || client.defaultScope || '';
+  var requestedScopes = requestedScope.split(' ');
+  var validScopes = client.validScopes.split(' ');
+  var isValid = !requestedScope || requestedScopes.every(function(key) {
         return validScopes.indexOf(key) !== -1;
       });
 
   if (user.allowedScopes) {
     var userAllowedScopes = user.allowedScopes.split(' ');
-    var scopes = validScopes.filter(function(key) {
-      return userAllowedScopes.indexOf(key) !== -1;
+    var userScopes = validScopes.filter(function(key) {
+      return (!scope || requestedScopes.indexOf(key) !== -1) && userAllowedScopes.indexOf(key) !== -1;
     });
-    scope = scopes.join(' ');
+    requestedScope = userScopes.join(' ');
   }
 
-  return callback(false, scope, isValid ? false : 'Invalid scope request');
+  return callback(false, requestedScope, isValid ? false : 'Invalid scope request');
 };
 
 /*

--- a/examples/postgresql/model.js
+++ b/examples/postgresql/model.js
@@ -103,22 +103,16 @@ model.saveAccessToken = function (accessToken, clientId, expires, userId, scope,
   });
 };
 
-model.saveRefreshToken = function (refreshToken, clientId, expires, userId, callback) {
+model.saveRefreshToken = function (refreshToken, clientId, expires, userId, scope, callback) {
   pg.connect(connString, function (err, client, done) {
     if (err) return callback(err);
-    // Retrieve the scope string from the access token entry
-    client.query('SELECT scope FROM oauth_access_tokens WHERE client_id = $1 AND user_id = $2',
-        [clientId, userId], function (err, result) {
-          if (err) return callback(err);
-          if (!result.rowCount) return callback('Could not retrieve access token scope string');
 
-          client.query('INSERT INTO oauth_refresh_tokens(refresh_token, client_id, ' +
-              'user_id, scope, expires) VALUES ($1, $2, $3, $4, $5)',
-              [refreshToken, clientId, userId, result.rows[0].scope, expires],
-              function (err, result) {
-                callback(err);
-                done();
-              });
+    client.query('INSERT INTO oauth_refresh_tokens(refresh_token, client_id, ' +
+        'user_id, scope, expires) VALUES ($1, $2, $3, $4, $5)',
+        [refreshToken, clientId, userId, scope, expires],
+        function (err, result) {
+          callback(err);
+          done();
         });
   });
 };

--- a/examples/postgresql/schema.sql
+++ b/examples/postgresql/schema.sql
@@ -48,7 +48,9 @@ CREATE TABLE oauth_access_tokens (
 CREATE TABLE oauth_clients (
     client_id text NOT NULL,
     client_secret text NOT NULL,
-    redirect_uri text NOT NULL
+    redirect_uri text NOT NULL,
+    valid_scopes text NULL,
+    default_scope text NULL
 );
 
 
@@ -72,7 +74,8 @@ CREATE TABLE oauth_refresh_tokens (
 CREATE TABLE users (
     id uuid NOT NULL,
     username text NOT NULL,
-    password text NOT NULL
+    password text NOT NULL,
+    allowed_scopes text NULL
 );
 
 

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -475,7 +475,7 @@ function saveRefreshToken (done) {
   }
 
   this.model.saveRefreshToken(refreshToken, this.client.clientId, expires,
-      this.user, function (err) {
+      this.user, this.scope, function (err) {
     if (err) return done(error('server_error', false, err));
     done();
   });

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -143,8 +143,10 @@ function checkClient (done) {
       return done(error('invalid_client', 'Client credentials are invalid'));
     }
 
-    // Expose validated client
-    self.scope = client.scope;
+    // Expose validated client scope information
+    self.client.validScopes = client.validScopes;
+    self.client.defaultScope = client.defaultScope;
+
     done();
   });
 }
@@ -363,7 +365,7 @@ function checkGrantTypeAllowed (done) {
  */
 function checkScope (done) {
   var self = this;
-  this.model.validateScope(this.scope, this.client.clientId,
+  this.model.validateScope(this.scope, this.client, this.user,
       function(err, scope, invalid) {
     if (err) return done(error('server_error', false, err));
 	if (invalid) return done(error('invalid_scope', invalid));
@@ -384,7 +386,8 @@ function exposeParams (done) {
   this.req.oauth = this.req.oauth || {};
   this.req.oauth.client = {
     id: this.client.clientId,
-    secret: this.client.clientSecret
+    secret: this.client.clientSecret,
+    scope: this.client.scope
   };
   this.req.user = this.user;
 

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -305,7 +305,7 @@ function useClientCredentialsGrant (done) {
     }
 
     self.user = user;
-    self.scope = self.client.scope;
+    self.scope = self.req.body.scope || self.client.defaultScope;
 
     done();
   });

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -386,8 +386,7 @@ function exposeParams (done) {
   this.req.oauth = this.req.oauth || {};
   this.req.oauth.client = {
     id: this.client.clientId,
-    secret: this.client.clientSecret,
-    scope: this.client.scope
+    secret: this.client.clientSecret
   };
   this.req.user = this.user;
 

--- a/test/grant.authorization_code.js
+++ b/test/grant.authorization_code.js
@@ -210,7 +210,7 @@ describe('Granting with authorization_code grant type', function () {
         expireRefreshToken: function (refreshToken, callback) {
           callback();
         },
-        validateScope: function (scope, clientId, cb) {
+        validateScope: function (scope, client, user, cb) {
           cb(null, 'foobar', false);
         }
       },

--- a/test/grant.extended.js
+++ b/test/grant.extended.js
@@ -132,7 +132,7 @@ describe('Granting with extended grant type', function () {
         saveAccessToken: function () {
           done(); // That's enough
         },
-        validateScope: function (scope, clientId, cb) {
+        validateScope: function (scope, client, user, cb) {
           cb(false, '', false);
         }
       },

--- a/test/grant.js
+++ b/test/grant.js
@@ -379,7 +379,7 @@ describe('Grant', function() {
           saveAccessToken: function (token, clientId, expires, user, scope, cb) {
             cb();
           },
-          saveRefreshToken: function (token, clientId, expires, user, cb) {
+          saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
             token.should.be.instanceOf(String);
             token.should.have.length(40);
             clientId.should.equal('thom');
@@ -460,7 +460,7 @@ describe('Grant', function() {
           saveAccessToken: function (token, clientId, expires, user, scope, cb) {
             cb();
           },
-          saveRefreshToken: function (token, clientId, expires, user, cb) {
+          saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
             cb();
           },
           validateScope: function (scope, client, user, cb) {
@@ -507,7 +507,7 @@ describe('Grant', function() {
           saveAccessToken: function (token, clientId, expires, user, scope, cb) {
             cb();
           },
-          saveRefreshToken: function (token, clientId, expires, user, cb) {
+          saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
             cb();
           },
           validateScope: function (scope, client, user, cb) {
@@ -555,7 +555,7 @@ describe('Grant', function() {
             should.strictEqual(null, expires);
             cb();
           },
-          saveRefreshToken: function (token, clientId, expires, user, cb) {
+          saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
             should.strictEqual(null, expires);
             cb();
           },

--- a/test/grant.js
+++ b/test/grant.js
@@ -241,7 +241,7 @@ describe('Grant', function() {
             token.should.equal('thommy');
             cb();
           },
-          validateScope: function (scope, clientId, cb) {
+          validateScope: function (scope, client, user, cb) {
             cb(null, '', false);
           }
         },
@@ -278,7 +278,7 @@ describe('Grant', function() {
             token.should.equal('thommy');
             cb();
           },
-          validateScope: function (scope, clientId, cb) {
+          validateScope: function (scope, client, user, cb) {
             cb(null, '', false);
           }
         },
@@ -311,7 +311,7 @@ describe('Grant', function() {
           saveAccessToken: function (token, clientId, expires, user, scope, cb) {
             cb(new Error('Should not be saving'));
           },
-          validateScope: function (scope, clientId, cb) {
+          validateScope: function (scope, client, user, cb) {
             cb(null, '', false);
           }
         },
@@ -349,7 +349,7 @@ describe('Grant', function() {
             (+expires).should.be.within(10, (+new Date()) + 3600000);
             cb();
           },
-          validateScope: function (scope, clientId, cb) {
+          validateScope: function (scope, client, user, cb) {
             cb(null, 'foobar', false);
           }
         },
@@ -387,7 +387,7 @@ describe('Grant', function() {
             (+expires).should.be.within(10, (+new Date()) + 1209600000);
             cb();
           },
-          validateScope: function (scope, clientId, cb) {
+          validateScope: function (scope, client, user, cb) {
             cb(null, '', false);
           }
         },
@@ -419,7 +419,7 @@ describe('Grant', function() {
           saveAccessToken: function (token, clientId, expires, user, scope, cb) {
             cb();
           },
-          validateScope: function (scope, clientId, cb) {
+          validateScope: function (scope, client, user, cb) {
             cb(null, '', false);
           }
         },
@@ -463,7 +463,7 @@ describe('Grant', function() {
           saveRefreshToken: function (token, clientId, expires, user, cb) {
             cb();
           },
-          validateScope: function (scope, clientId, cb) {
+          validateScope: function (scope, client, user, cb) {
             cb(null, '', false);
           }
         },
@@ -510,7 +510,7 @@ describe('Grant', function() {
           saveRefreshToken: function (token, clientId, expires, user, cb) {
             cb();
           },
-          validateScope: function (scope, clientId, cb) {
+          validateScope: function (scope, client, user, cb) {
             cb(null, 'foobar', false);
           }
         },
@@ -559,7 +559,7 @@ describe('Grant', function() {
             should.strictEqual(null, expires);
             cb();
           },
-          validateScope: function (scope, clientId, cb) {
+          validateScope: function (scope, client, user, cb) {
             cb(null, '', false);
           }
         },
@@ -603,7 +603,7 @@ describe('Grant', function() {
           saveAccessToken: function (token, clientId, expires, user, scope, cb) {
             cb();
           },
-          validateScope: function (scope, clientId, cb) {
+          validateScope: function (scope, client, user, cb) {
             cb(null, '', false);
           }
         },
@@ -651,7 +651,7 @@ describe('Grant', function() {
             (+expires).should.be.within(10, (+new Date()) + 3600000);
             cb();
           },
-          validateScope: function(scope, clientId, cb) {
+          validateScope: function(scope, client, user, cb) {
             cb(false, false, true);
           }
         },
@@ -686,7 +686,7 @@ describe('Grant', function() {
             (+expires).should.be.within(10, (+new Date()) + 3600000);
             cb();
           },
-          validateScope: function(scope, clientId, cb) {
+          validateScope: function(scope, client, user, cb) {
             cb(false, 'foo bar', false);
           }
         },

--- a/test/grant.refresh_token.js
+++ b/test/grant.refresh_token.js
@@ -180,7 +180,7 @@ describe('Granting with refresh_token grant type', function () {
         expireRefreshToken: function (refreshToken, callback) {
           callback();
         },
-        validateScope: function (scope, clientId, cb) {
+        validateScope: function (scope, client, user, cb) {
           cb(false, '', false);
         }
       },
@@ -228,7 +228,7 @@ describe('Granting with refresh_token grant type', function () {
         expireRefreshToken: function (refreshToken, callback) {
           callback();
         },
-        validateScope: function (scope, clientId, cb) {
+        validateScope: function (scope, client, user, cb) {
           cb(false, '', false);
         }
       },
@@ -273,7 +273,7 @@ describe('Granting with refresh_token grant type', function () {
         expireRefreshToken: function (refreshToken, callback) {
           callback();
         },
-        validateScope: function (scope, clientId, cb) {
+        validateScope: function (scope, client, user, cb) {
           cb(false, '', false);
         }
       },

--- a/test/grant.refresh_token.js
+++ b/test/grant.refresh_token.js
@@ -174,7 +174,7 @@ describe('Granting with refresh_token grant type', function () {
         saveAccessToken: function (token, clientId, expires, user, scope, cb) {
           cb();
         },
-        saveRefreshToken: function (token, clientId, expires, user, cb) {
+        saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
           cb();
         },
         expireRefreshToken: function (refreshToken, callback) {
@@ -222,7 +222,7 @@ describe('Granting with refresh_token grant type', function () {
         saveAccessToken: function (token, clientId, expires, user, scope, cb) {
           cb();
         },
-        saveRefreshToken: function (token, clientId, expires, user, cb) {
+        saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
           cb();
         },
         expireRefreshToken: function (refreshToken, callback) {
@@ -267,7 +267,7 @@ describe('Granting with refresh_token grant type', function () {
         saveAccessToken: function (token, clientId, expires, user, scope, cb) {
           cb();
         },
-        saveRefreshToken: function (token, clientId, expires, user, cb) {
+        saveRefreshToken: function (token, clientId, expires, scope, user, cb) {
           cb();
         },
         expireRefreshToken: function (refreshToken, callback) {


### PR DESCRIPTION
This is a proposal to address [the question](https://github.com/thomseddon/node-oauth2-server/pull/149#issuecomment-93721507) I raised a couple days ago. It allows filtering scopes by user permissions by attaching "valid" and "default" scopes to the client and "allowed" scopes to the user object. These can be checked in `validateScopes`
